### PR TITLE
Add  @hidetraceback to ignore internal logging

### DIFF
--- a/src/expycted/internals/filesystem.py
+++ b/src/expycted/internals/filesystem.py
@@ -1,7 +1,7 @@
 import os
 from typing import Tuple, Type, Union
 
-from expycted.internals.utils import to_not_fn
+from expycted.internals.utils import hidetraceback, to_not_fn
 
 assertion_texts = {
     "contain": "Expected {value1} to contain {value2}",
@@ -71,6 +71,7 @@ class To:
             value1=self.path
         )
 
+    @hidetraceback
     def contain(
         self, name: str, type: Union[Type[File], Type[Folder], None, str] = None
     ) -> None:
@@ -80,6 +81,7 @@ class To:
         res = self._internal_contain(name, type)
         assert res[0], res[1]
 
+    @hidetraceback
     def contain_file(self, name: str) -> None:
         """
         Check if folder contains file with given name
@@ -87,6 +89,7 @@ class To:
         res = self._internal_contain_file(name)
         assert res[0], res[1]
 
+    @hidetraceback
     def contain_folder(self, name: str) -> None:
         """
         Check if folder contains folder with given name
@@ -94,6 +97,7 @@ class To:
         res = self._internal_contain_folder(name)
         assert res[0], res[1]
 
+    @hidetraceback
     def exist(self) -> None:
         """
         Check if folder exists
@@ -101,6 +105,7 @@ class To:
         res = self._internal_exist()
         assert res[0], res[1]
 
+    @hidetraceback
     def be_empty(self) -> None:
         """
         Check if folder is empty

--- a/src/expycted/internals/function.py
+++ b/src/expycted/internals/function.py
@@ -1,5 +1,7 @@
 from typing import Any, Callable, Type
 
+from expycted.internals.utils import hidetraceback
+
 assertion_texts = {
     "to_raise": "Expected function `{function}` to raise {exc} when called with: {arguments}",
     "to_return": "Expected function {function} to return {value} when called with: {arguments}",
@@ -62,6 +64,7 @@ class ToRaise:
         self.function = function
         self.exception = exception
 
+    @hidetraceback
     def when_called_with(self, *args, **kwargs):
         """Arguments to call the function with
 
@@ -93,6 +96,7 @@ class ToReturn:
         self.value = value
         self.type_of_value = type_of_value
 
+    @hidetraceback
     def when_called_with(self, *args, **kwargs):
         """Arguments to call the function with
 

--- a/src/expycted/internals/function.py
+++ b/src/expycted/internals/function.py
@@ -79,7 +79,7 @@ class ToRaise:
                 exc=self.exception, 
                 arguments=format_args_kwargs(args, kwargs))
         else:
-            raise AssertionError(
+            raise ValueError(
                 f"Expected '{self.exception}' to be raised, but nothing was raised"
             )
 

--- a/src/expycted/internals/function.py
+++ b/src/expycted/internals/function.py
@@ -32,7 +32,7 @@ class Function:
             AssertionError: When neither of type_of_value and value is not provided AssertionError is raised
         """
         if value is None and type_of_value is None:
-            raise AssertionError(
+            raise ValueError(
                 "You must specify either value or type_of_value in to_return function"
             )
         else:
@@ -79,7 +79,7 @@ class ToRaise:
                 exc=self.exception, 
                 arguments=format_args_kwargs(args, kwargs))
         else:
-            raise ValueError(
+            raise AssertionError(
                 f"Expected '{self.exception}' to be raised, but nothing was raised"
             )
 

--- a/src/expycted/internals/utils.py
+++ b/src/expycted/internals/utils.py
@@ -3,23 +3,6 @@ from functools import wraps
 from typing import Callable
 
 
-def to_not_fn(fn: Callable) -> Callable:
-    """Returns a function that negates the result of the provided function
-
-    Args:
-        fn (Callable): Function to negate
-        *args: Arguments to pass to the function
-
-    Returns:
-        Callable: Negated function
-    """
-
-    def to_not_fn_inner(*args, **kwargs):
-        res = fn(*args, **kwargs)
-        assert not res[0], res[1].replace("to", "to not")
-
-    return to_not_fn_inner
-
 def hidetraceback(fn: Callable) -> Callable:
     """Decorate helper methods to ignore internal assertion traceback
 
@@ -35,3 +18,20 @@ def hidetraceback(fn: Callable) -> Callable:
         return fn(*args, **kwargs)
 
     return _
+
+def to_not_fn(fn: Callable) -> Callable:
+    """Returns a function that negates the result of the provided function
+
+    Args:
+        fn (Callable): Function to negate
+        *args: Arguments to pass to the function
+
+    Returns:
+        Callable: Negated function
+    """
+    @wraps(fn)
+    def to_not_fn_inner(*args, **kwargs):
+        res = fn(*args, **kwargs)
+        assert not res[0], res[1].replace("to", "to not")
+
+    return hidetraceback(to_not_fn_inner)

--- a/src/expycted/internals/utils.py
+++ b/src/expycted/internals/utils.py
@@ -1,4 +1,5 @@
 import os
+from functools import wrap
 from typing import Callable
 
 

--- a/src/expycted/internals/utils.py
+++ b/src/expycted/internals/utils.py
@@ -29,9 +29,10 @@ def to_not_fn(fn: Callable) -> Callable:
     Returns:
         Callable: Negated function
     """
+    @hidetraceback
     @wraps(fn)
     def to_not_fn_inner(*args, **kwargs):
         res = fn(*args, **kwargs)
         assert not res[0], res[1].replace("to", "to not")
 
-    return hidetraceback(to_not_fn_inner)
+    return to_not_fn_inner

--- a/src/expycted/internals/utils.py
+++ b/src/expycted/internals/utils.py
@@ -1,5 +1,5 @@
 import os
-from functools import wrap
+from functools import wraps
 from typing import Callable
 
 

--- a/src/expycted/internals/utils.py
+++ b/src/expycted/internals/utils.py
@@ -1,3 +1,4 @@
+import os
 from typing import Callable
 
 
@@ -17,3 +18,19 @@ def to_not_fn(fn: Callable) -> Callable:
         assert not res[0], res[1].replace("to", "to not")
 
     return to_not_fn_inner
+
+def hidetraceback(fn: Callable) -> Callable:
+    """Decorate helper methods to ignore internal assertion traceback
+
+    Args:
+        fn (Callable): Function to decorate
+
+    Returns:
+        Callable: The decorated function
+    """
+    @wraps(fn)
+    def _(*args, **kwargs):
+        fn.__globals__['__tracebackhide__'] = os.getenv('EXPYCTED_HIDETRACEBACK', True)
+        return fn(*args, **kwargs)
+
+    return _

--- a/src/expycted/internals/value.py
+++ b/src/expycted/internals/value.py
@@ -1,7 +1,7 @@
 import pickle
 from typing import Any, Callable, Collection, Tuple
 
-from expycted.internals.utils import to_not_fn
+from expycted.internals.utils import hidetraceback, to_not_fn
 
 assertion_texts = {
     "equal": "Expected {value1} to equal {value2}",
@@ -144,6 +144,7 @@ class To:
                 return False, assertion_text
         return False, assertion_text
 
+    @hidetraceback
     def equal(self, something: Any) -> None:
         """Checks whether that the value is equal to something
 
@@ -156,6 +157,7 @@ class To:
         res = self._internal_equal(something)
         assert res[0], res[1]
 
+    @hidetraceback
     def be(self, something: Any) -> None:
         """Checks whether the value is 'softly' equal to something
 
@@ -169,6 +171,7 @@ class To:
         res = self._internal_be(something)
         assert res[0], res[1]
 
+    @hidetraceback
     def contain(self, something: Any) -> None:
         """Checks whether the value contains something
 
@@ -181,6 +184,7 @@ class To:
         res = self._internal_contain(something)
         assert res[0], res[1]
 
+    @hidetraceback
     def be_contained_in(self, something: Collection) -> None:
         """Checks whether the value is contained in something
 
@@ -193,6 +197,7 @@ class To:
         res = self._internal_be_contained_in(something)
         assert res[0], res[1]
 
+    @hidetraceback
     def be_empty(self) -> None:
         """Checks whether the value is empty
 
@@ -202,6 +207,7 @@ class To:
         res = self._internal_be_empty()
         assert res[0], res[1]
 
+    @hidetraceback
     def be_true(self) -> None:
         """Checks whether the value is true
 
@@ -211,6 +217,7 @@ class To:
         res = self._internal_be_true()
         assert res[0], res[1]
 
+    @hidetraceback
     def be_false(self) -> None:
         """Checks whether the value is false
 
@@ -220,6 +227,7 @@ class To:
         res = self._internal_be_false()
         assert res[0], res[1]
 
+    @hidetraceback
     def be_truthy(self) -> None:
         """Checks whether the value is truthy
 
@@ -229,6 +237,7 @@ class To:
         res = self._internal_be_truthy()
         assert res[0], res[1]
 
+    @hidetraceback
     def be_falsey(self) -> None:
         """Checks whether the value is falsey
 
@@ -238,6 +247,7 @@ class To:
         res = self._internal_be_falsey()
         assert res[0], res[1]
 
+    @hidetraceback
     def be_of_type(self, something: type) -> None:
         """Checks whether the value is of provided type
 
@@ -250,6 +260,7 @@ class To:
         res = self._internal_be_of_type(something)
         assert res[0], res[1]
 
+    @hidetraceback
     def inherit(self, something: type) -> None:
         """Checks whether the value inherits from provided type
 
@@ -262,6 +273,7 @@ class To:
         res = self._internal_inherit(something)
         assert res[0], res[1]
 
+    @hidetraceback
     def be_greater_than(self, something: Any) -> None:
         """Check whether the value is greater than something
 
@@ -274,6 +286,7 @@ class To:
         res = self._internal_be_greater_than(something)
         assert res[0], res[1]
 
+    @hidetraceback
     def be_lesser_than(self, something: Any) -> None:
         """Check whether the value is lesser than something
 
@@ -286,6 +299,7 @@ class To:
         res = self._internal_be_lesser_than(something)
         assert res[0], res[1]
 
+    @hidetraceback
     def be_greater_or_equal_to(self, something: Any) -> None:
         """Check whether the value is greater than or equal to something
 
@@ -298,6 +312,7 @@ class To:
         res = self._internal_be_greater_or_equal_to(something)
         assert res[0], res[1]
 
+    @hidetraceback
     def be_lesser_or_equal_to(self, something: Any) -> None:
         """Check whether the value is lesser than or equal to something
 
@@ -310,6 +325,7 @@ class To:
         res = self._internal_be_lesser_or_equal_to(something)
         assert res[0], res[1]
 
+    @hidetraceback
     def be_numeric(self) -> None:
         """Check whether the value is numeric
 

--- a/test/expect_function_test_suite.py
+++ b/test/expect_function_test_suite.py
@@ -39,7 +39,6 @@ def test_fn_expect_raise(fn, arguments, exc_class, raises):
         (map, [lambda x: x + 1, [1, 2, 3]], None, map, True),
         (map, [lambda x: x + 1, [1, 2, 3]], None, list, False),
         ("string".replace, ["ing", "ength"], "strengt", None, False),
-        (str, [10], None, None, False),
     ],
 )
 def test_fn_expect_return(fn, arguments, ret_value, ret_type, true):
@@ -53,3 +52,7 @@ def test_fn_expect_return(fn, arguments, ret_value, ret_type, true):
         expect.function(fn).to_return(
             value=ret_value, type_of_value=ret_type
         ).when_called_with(*arguments)
+
+def test_fn_raises_value_error_when_called_without_return():
+    with pytest.raises(ValueError):
+        expect.function(str).to_return().when_called_with([10])


### PR DESCRIPTION
The `@hidetraceback` decorator removes internal stack traces from the outputted assert message.

Assuming the following code:
```python
from expycted import expect

def test():
    expect('hello').to.contain('lla')
```

**Before:**
```text
--------------------------- test ---------------------------
def test():
>   expect('hello').to.contain('lla')

--------------------------- 
self = <expycted.internals.value.To object at 0x0000000>, something = 'lla'

    def contain(self, something: Any) -> None:
        """Checks whether the value contains something
        Args:
            something (Any): The value to be contained
        Returns:
            bool: Result
        """
        res = self._internal_contain(something)
>      assert res[0], res[1]
AssertionError: Expected hello to contain lla
```

**After:**
```text
--------------------------- test ---------------------------
def test():
>   expect('hello').to.contain('lla')
AssertionError: Expected hello to contain lla
```