### PR TITLE
Support Path objects in directory expectations

### DIFF
--- a/src/expycted/__init__.py
+++ b/src/expycted/__init__.py
@@ -1,4 +1,5 @@
-from typing import Callable, Any
+from pathlib import Path
+from typing import Callable, Any, Union
 
 from expycted.internals.filesystem import Directory
 from expycted.internals.function import Function
@@ -25,11 +26,11 @@ class expect(Value):
         return cls(value)
 
     @classmethod
-    def folder(cls, path: str):
+    def folder(cls, path: Union[str, Path]):
         """Expect a folder to be something
 
         Args:
-            path (str): Path to folder to check for some sort of condition
+            path (str|Path): Path to folder to check for some sort of condition
         """
         return Directory(path)
 

--- a/src/expycted/internals/filesystem.py
+++ b/src/expycted/internals/filesystem.py
@@ -1,7 +1,7 @@
-import os
+from pathlib import Path
 from typing import Tuple, Type, Union
 
-from expycted.internals.utils import assertion
+from expycted.internals.utils import assertion, hidetraceback
 from expycted.internals.base import BaseExpectation
 
 
@@ -13,11 +13,6 @@ class Folder:
     pass
 
 
-def check_stringiness(param):
-    if not isinstance(param, str):
-        raise AssertionError(f"Expected a string, got a {type(param)}")
-
-
 class Directory(BaseExpectation):
     _ASSERTION_MESSAGES = {
         "contain": "Expected {value1} to contain {value2}",
@@ -27,67 +22,69 @@ class Directory(BaseExpectation):
         "be_empty": "Expected {value1} to be empty",
     }
 
-    def __init__(self, value: str):
-        super().__init__(value)
-        check_stringiness(self.value)
+    def __init__(self, value: Union[str, Path]):
+        super().__init__(self._normalize(value))
+
+    @staticmethod
+    def _normalize(value: Union[str, Path]) -> Path:
+        if not isinstance(value, (str, Path)):
+            raise AssertionError(f"Expected a string or Path, got a {type(value)}")
+
+        return Path(value)
 
     def _internal_contain(
-        self, name: str, type: Union[Type[File], Type[Folder], None, str] = None
+            self,
+            name: str,
+            type_: Union[Type[File], Type[Folder], None, str] = None
     ) -> Tuple[bool, str]:
-        check_stringiness(name)
-        if type == File or str(type).lower() == "file":
-            return os.path.isfile(os.path.join(self.value, name)), self._message("contain_file", name)
+        name = self.value.joinpath(self._normalize(name))
 
-        if type == Folder or str(type).lower() == "folder":
-            return os.path.isdir(os.path.join(self.value, name)), self._message("contain_folder", name)
+        if type_ == File or str(type_).lower() == "file":
+            return name.is_file(), self._message("contain_file", name)
 
-        return os.path.exists(os.path.join(self.value, name)), self._message("contain", name)
+        if type_ == Folder or str(type_).lower() == "folder":
+            return name.is_dir(), self._message("contain_folder", name)
 
-    def _internal_contain_file(self, name: str) -> Tuple[bool, str]:
-        return self._internal_contain(name, type=File)
-
-    def _internal_contain_folder(self, name: str) -> Tuple[bool, str]:
-        return self._internal_contain(name, type=Folder)
+        return name.exists(), self._message("contain", name)
 
     def _internal_exist(self) -> Tuple[bool, str]:
-        return os.path.exists(self.value), self._message("exist")
+        return self.value.exists(), self._message("exist")
 
     def _internal_be_empty(self) -> Tuple[bool, str]:
-        return os.listdir(self.value) == [], self._message("be_empty")
+        return not any(self.value.iterdir()), self._message("be_empty")
 
     @assertion
     def contain(
-        self, name: str, type: Union[Type[File], Type[Folder], None, str] = None
+            self,
+            name: str,
+            type_: Union[Type[File], Type[Folder], None, str] = None
     ) -> None:
         """
         Check if folder contains something with given name
         """
-        pass
 
-    @assertion
+    @hidetraceback
     def contain_file(self, name: str) -> None:
         """
         Check if folder contains file with given name
         """
-        pass
+        return self.contain(name, type_=File)
 
-    @assertion
+    @hidetraceback
     def contain_folder(self, name: str) -> None:
         """
         Check if folder contains folder with given name
         """
-        pass
+        return self.contain(name, type_=Folder)
 
     @assertion
     def exist(self) -> None:
         """
         Check if folder exists
         """
-        pass
 
     @assertion
     def be_empty(self) -> None:
         """
         Check if folder is empty
         """
-        pass

--- a/test/expect_filesystem_test_suite.py
+++ b/test/expect_filesystem_test_suite.py
@@ -1,4 +1,6 @@
 import pytest
+from pathlib import Path
+
 from expycted import expect
 
 from helpers.utils import expected_params
@@ -9,19 +11,21 @@ def get_test_directory(tmp_path):
     tmp_path.joinpath("test_file.txt").write_text("test")
     tmp_path.joinpath("test_file2.txt").write_text("test")
 
-    return tmp_path.as_posix()
+    return tmp_path
 
 
 @pytest.fixture(name="empty_directory")
 def get_empty_test_directory(tmp_path):
     tmp_path.joinpath("empty").mkdir()
-    return tmp_path.joinpath("empty").as_posix()
+
+    return tmp_path.joinpath("empty")
 
 
 @pytest.fixture(name="with_subdirectory")
 def get_test_directory_with_subdirectory(tmp_path):
     tmp_path.joinpath("subdirectory").mkdir()
-    return tmp_path.as_posix()
+
+    return tmp_path
 
 
 def test_to_contain(directory, with_subdirectory, context):
@@ -41,6 +45,7 @@ def test_to_contain(directory, with_subdirectory, context):
 
     with context.raises:
         expect.folder(directory).to.contain("test_file3.txt")
+
 
 def test_to_contain_file(directory, context):
     expect.folder(directory).to.contain_file("test_file.txt")
@@ -65,7 +70,6 @@ def test_to_be_empty(directory, empty_directory, with_subdirectory, context):
     with context.raises:
         expect.folder(empty_directory).to_not.be_empty()
 
-
     with context.raises:
         expect.folder(with_subdirectory).to.be_empty()
 
@@ -82,6 +86,7 @@ def test_to_contain_folder(with_subdirectory, empty_directory, context):
 
     with context.raises:
         expect.folder(empty_directory).to.contain_folder("subdirectory")
+
 
 def test_to_exist(directory, context):
     expect.folder(directory).to.exist()
@@ -101,3 +106,7 @@ def test_passing_wrong_types(expected, context):
 
     with context.raises:
         expect.folder(expected).to_not.exist()
+
+
+def test_path_object_type(directory):
+    expect.folder(directory).to.contain(Path("test_file.txt"))


### PR DESCRIPTION
Support `Path` objects in directory expectations.

Closes #19 